### PR TITLE
Support for NTLM v2 Only Auth level

### DIFF
--- a/NtlmHttpHandlerFactory.cs
+++ b/NtlmHttpHandlerFactory.cs
@@ -15,6 +15,9 @@ Make sure you you've added the following types to your linker.xml:
         <type fullname=""System.Net.Http.HttpClientHandler*"" />
         <type fullname=""System.Net.Http.MonoWebRequestHandler*"" />
     </assembly>
+    <assembly fullname=""Mono.Security"">
+        <type fullname=""Mono.Security.Protocol.Ntlm.NtlmSettings*"" />
+    </assembly>
 </linker>";
 
         public static HttpClientHandler Create(bool ntlmV2Only = false)


### PR DESCRIPTION
When the server doing the NTLM authentication has been set up to NTLM V2 Only and to refuse LM and NTLM then authentication will fail unless the AuthLevel of the client has been set to NTLMv2Only.